### PR TITLE
Add new class for specialized type erasure

### DIFF
--- a/src/oki/util/oki_type_erasure.h
+++ b/src/oki/util/oki_type_erasure.h
@@ -1,0 +1,263 @@
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace oki
+{
+    namespace intl_
+    {
+        namespace helper_
+        {
+            enum class AnyErasedOperations
+            {
+                COPY_CONSTR,
+                COPY_ASSIGN,
+                MOVE_CONSTR,
+                MOVE_ASSIGN,
+                DESTROY
+            };
+        }
+
+        /*
+         * This is a class designed for a very specialized purpose: obscure
+         * the type of an object whose type is known by the caller.
+         * It is capable of small-buffer optimizing objects of a particular
+         * size and alignment (making it perhaps useful for a heterogeneous
+         * container of a template class with different instantiations?)
+         *
+         * Per the assumption that the caller *knows the type*, there is NO
+         * TYPE CHECKING for ANY operation. It is optimized for performance and
+         * is able to function without RTTI. Such is the benefit over std::any.
+         */
+        template <std::size_t Size, std::size_t Align>
+        class ErasedType
+        {
+        public:
+            ErasedType(const ErasedType<Size, Align>& that)
+                : budgetVtable_(that.budgetVtable_)
+            {
+                this->budgetVtable_(*this, &that, Operation::COPY_CONSTR);
+            }
+
+            ErasedType(ErasedType<Size, Align>&& that)
+                : budgetVtable_(that.budgetVtable_)
+            {
+                this->budgetVtable_(*this, &that, Operation::MOVE_CONSTR);
+            }
+
+            ~ErasedType()
+            {
+                this->budgetVtable_(*this, nullptr, Operation::DESTROY);
+            }
+
+            /*
+             * As an example of the above, there is no guarantee that the other
+             * ErasedType<> holds a type that is equivalent to this one. It falls
+             * on the caller to be sure they're correct.
+             */
+            ErasedType<Size, Align>& operator=(const ErasedType<Size, Align>& that)
+            {
+                this->budgetVtable_(*this, &that, Operation::COPY_ASSIGN);
+                return *this;
+            }
+
+            ErasedType<Size, Align>& operator=(ErasedType<Size, Align>&& that)
+            {
+                this->budgetVtable_(*this, &that, Operation::MOVE_ASSIGN);
+                return *this;
+            }
+
+            /*
+             * Returns a reference to the stored value, assuming (and not
+             * checking whether) the caller is correct about the type.
+             */
+            template <typename Type>
+            const Type& get_as() const
+            {
+                return *this->get_data_<Type>();
+            }
+
+            template <typename Type>
+            Type& get_as()
+            {
+                return const_cast<Type&>(
+                    std::as_const(*this).template get_as<Type>()
+                );
+            }
+
+            /*
+             * Takes a value matching the underlying type and assigns
+             * it to the internal object with perfect forwarding.
+             *
+             * This should be preferred over assigning the ErasedType<>.
+             */
+            template <typename Type, typename InsertType>
+            void hold(InsertType&& value)
+            {
+                this->get_as<Type>() = std::forward<InsertType>(value);
+            }
+
+            /*
+             * Copy-assigns the value in the provided ErasedType<> to the
+             * one in this instance.
+             *
+             * Should be preferred over assignment.
+             */
+            template <typename Type>
+            void copy_from(const ErasedType<Size, Align>& that)
+            {
+                this->hold<Type>(that.get_as<Type>());
+            }
+
+            /*
+             * Move-assigns the value in the provided ErasedType<> to the
+             * one in this instance.
+             *
+             * Should be preferred over assignment.
+             */
+            template <typename Type>
+            void move_from(ErasedType<Size, Align>&& that)
+            {
+                this->hold<Type>(std::move(that.get_as<Type>()));
+            }
+
+            /*
+             * Creates an ErasedType<> instace holding a value of type Type,
+             * constructing one in-place by perfectly forwarding the variadic
+             * arguments.
+             */
+            template <typename Type, typename... Args>
+            static ErasedType<Size, Align> erase_type(Args&&... args)
+            {
+                ErasedType<Size, Align> ret;
+
+                if constexpr (is_small_buffered<Type>::value)
+                {
+                    new (ret.storage_.buf_) Type{ std::forward<Args>(args)... };
+                }
+                else
+                {
+                    ret.storage_.ptr_ = new Type{ std::forward<Args>(args)... };
+                }
+                ret.budgetVtable_ = erased_ops_<Type>;
+
+                return ret;
+            }
+
+        private:
+            union Storage
+            {
+                alignas(Align) std::byte buf_[Size];
+                void* ptr_;
+            } storage_;
+
+            using Operation = oki::intl_::helper_::AnyErasedOperations;
+
+            // The name is a bit tongue-in-cheek but it gets the point across
+            void (*budgetVtable_)(
+                ErasedType<Size, Align>&,
+                const ErasedType<Size, Align>*,
+                Operation
+            );
+
+            template <typename Type>
+            using is_small_buffered =
+                std::conditional_t<
+                    alignof(Type) <= Align && sizeof(Type) <= Size,
+                    std::true_type,
+                    std::false_type
+                >;
+
+            template <typename Type>
+            const Type* get_data_() const
+            {
+                if constexpr (is_small_buffered<Type>::value)
+                {
+                    return std::launder(
+                        reinterpret_cast<const Type*>(
+                            &storage_.buf_
+                        )
+                    );
+                }
+                else
+                {
+                    return static_cast<const Type*>(storage_.ptr_);
+                }
+            }
+
+            template <typename Type>
+            Type* get_data_()
+            {
+                return const_cast<Type*>(
+                    std::as_const(*this).template get_data_<Type>()
+                );
+            }
+
+            template <typename Type>
+            static void erased_ops_(
+                ErasedType<Size, Align>& self,
+                const ErasedType<Size, Align>* other,
+                Operation op)
+            {
+                if constexpr (is_small_buffered<Type>::value)
+                {
+                    switch (op)
+                    {
+                    case Operation::MOVE_CONSTR:
+                        new (self.storage_.buf_) Type{
+                            std::move(const_cast<Type&>(other->get_as<Type>()))
+                        };
+                        break;
+                    case Operation::MOVE_ASSIGN:
+                        self.move_from<Type>(
+                            std::move(*const_cast<ErasedType<Size, Align>*>(other))
+                        );
+                        break;
+                    case Operation::COPY_CONSTR:
+                        new (self.storage_.buf_) Type{
+                            other->get_as<Type>()
+                        };
+                        break;
+                    case Operation::COPY_ASSIGN:
+                        self.copy_from<Type>(*other);
+                        break;
+                    case Operation::DESTROY:
+                        std::destroy_at(self.get_data_<Type>());
+                        break;
+                    }
+                }
+                else
+                {
+                    switch (op)
+                    {
+                    case Operation::MOVE_CONSTR:
+                    case Operation::MOVE_ASSIGN:
+                        std::swap(
+                            self.storage_.ptr_,
+                            const_cast<ErasedType<Size, Align>*>(other)->storage_.ptr_
+                        );
+                        break;
+                    case Operation::COPY_CONSTR:
+                        self.storage_.ptr_ = new Type{
+                            other->get_as<Type>()
+                        };
+                        break;
+                    case Operation::COPY_ASSIGN:
+                        self.copy_from<Type>(*other);
+                        break;
+                    case Operation::DESTROY:
+                        delete self.get_data_<Type>();
+                        break;
+                    }
+                }
+            }
+
+            ErasedType() = default;
+        };
+
+        template <typename Type>
+        using OptimalErasedType = ErasedType<sizeof(Type), alignof(Type)>;
+    }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,6 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Catch2)
 
-add_executable(oki_unit oki_test_handle.cpp oki_test_container.cpp)
+add_executable(oki_unit oki_test_handle.cpp oki_test_container.cpp oki_test_type_erasure.cpp)
 target_include_directories(oki_unit PRIVATE "../src/")
 target_link_libraries(oki_unit PRIVATE Catch2::Catch2WithMain)

--- a/test/oki_test_type_erasure.cpp
+++ b/test/oki_test_type_erasure.cpp
@@ -1,0 +1,268 @@
+#include "oki/util/oki_type_erasure.h"
+#include "oki/oki_handle.h"
+
+#include "catch2/catch_test_macros.hpp"
+#include "catch2/catch_template_test_macros.hpp"
+
+#include <cstdint>
+#include <utility>
+
+namespace test_helper
+{
+    struct ObjHelper
+    {
+        static inline std::size_t
+            numConstructs = 0,
+            numCopies = 0,
+            numMoves = 0,
+            numDestructs = 0;
+
+        ObjHelper()
+            : value_(0)
+        {
+            ++numConstructs;
+        }
+
+        ObjHelper(std::size_t value)
+            : value_(value)
+        {
+            ++numConstructs;
+        }
+
+        ObjHelper(const ObjHelper& that)
+            : value_(that.value_)
+        {
+            ++numConstructs;
+            ++numCopies;
+        }
+
+        ObjHelper(ObjHelper&& that)
+            : value_(that.value_)
+        {
+            ++numConstructs;
+            ++numMoves;
+        }
+
+        ~ObjHelper()
+        {
+            ++numDestructs;
+        }
+
+        ObjHelper& operator=(const ObjHelper& that)
+        {
+            ++numCopies;
+            value_ = that.value_;
+            return (*this);
+        }
+
+        ObjHelper& operator=(ObjHelper&& that)
+        {
+            ++numMoves;
+            value_ = that.value_;
+            return (*this);
+        }
+
+        static void reset()
+        {
+            numConstructs = numCopies = numMoves = numDestructs = 0;
+        }
+
+        static void test()
+        {
+            CHECK(numConstructs == numDestructs);
+        }
+
+        std::size_t value_;
+    };
+}
+
+using Value = test_helper::ObjHelper;
+
+TEMPLATE_TEST_CASE("ErasedType", "[logic][ecs][type]",
+    (oki::intl_::OptimalErasedType<test_helper::ObjHelper>),
+    (oki::intl_::ErasedType<1, 1>)) // Undersized so won't fit an ObjHelper
+{
+    Value::reset();
+
+    SECTION("default constructs when no arguments are provided")
+    {
+        {
+            // The ugly template specifier is only required because
+            // TestType is a template as well, and won't be necessary
+            // in general use
+            auto value = TestType::template erase_type<Value>();
+
+            REQUIRE(value.template get_as<Value>().value_ == 0);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 1);
+        CHECK(Value::numCopies == 0);
+        CHECK(Value::numMoves == 0);
+    }
+    SECTION("calls constructor on arguments")
+    {
+        {
+            auto value = TestType::template erase_type<Value>(1u);
+
+            REQUIRE(value.template get_as<Value>().value_ == 1);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 1);
+        CHECK(Value::numCopies == 0);
+        CHECK(Value::numMoves == 0);
+    }
+    SECTION("move constructs when same type is moved in")
+    {
+        {
+            auto init = Value(1u);
+            auto value = TestType::template erase_type<Value>(std::move(init));
+
+            REQUIRE(value.template get_as<Value>().value_ == init.value_);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 0);
+        CHECK(Value::numMoves == 1);
+    }
+    SECTION("copy constructs when same type is copied in")
+    {
+        {
+            auto init = Value(1u);
+            auto value = TestType::template erase_type<Value>(init);
+
+            REQUIRE(value.template get_as<Value>().value_ == init.value_);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 1);
+        CHECK(Value::numMoves == 0);
+    }
+    SECTION("copies and properly destructs after copy assignment")
+    {
+        {
+            auto value1 = TestType::template erase_type<Value>(1u);
+            auto value2 = TestType::template erase_type<Value>(2u);
+
+            value1 = value2;
+
+            REQUIRE(value1.template get_as<Value>().value_ == 2);
+            REQUIRE(value2.template get_as<Value>().value_ == 2);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 1);
+        CHECK(Value::numMoves == 0);
+    }
+    SECTION("moves and properly destructs after move assignment")
+    {
+        {
+            auto value1 = TestType::template erase_type<Value>(1u);
+            auto value2 = TestType::template erase_type<Value>(2u);
+
+            value1 = std::move(value2);
+
+            REQUIRE(value1.template get_as<Value>().value_ == 2);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 0);
+        CHECK(Value::numMoves <= 1); // Unbuffered simply swaps pointers
+    }
+    SECTION("moves and properly destructs after copy_from()")
+    {
+        {
+            auto value1 = TestType::template erase_type<Value>(1u);
+            auto value2 = TestType::template erase_type<Value>(2u);
+
+            value1.template copy_from<Value>(value2);
+
+            REQUIRE(value1.template get_as<Value>().value_ == 2);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 1);
+        CHECK(Value::numMoves == 0);
+    }
+    SECTION("moves and properly destructs after move_from()")
+    {
+        {
+            auto value1 = TestType::template erase_type<Value>(1u);
+            auto value2 = TestType::template erase_type<Value>(2u);
+
+            value1.template move_from<Value>(std::move(value2));
+
+            REQUIRE(value1.template get_as<Value>().value_ == 2);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 0);
+        CHECK(Value::numMoves <= 1);
+    }
+    SECTION("properly destructs after copy self-assignment")
+    {
+        {
+            auto value = TestType::template erase_type<Value>(1u);
+            value = value;
+
+            CHECK(value.template get_as<Value>().value_ == 1);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 1);
+        CHECK(Value::numCopies == 1);
+        CHECK(Value::numMoves == 0);
+    }
+    SECTION("can assign rvalues with hold()")
+    {
+        {
+            auto value = TestType::template erase_type<Value>(1u);
+            value.template hold<Value>(Value{ 2 });
+
+            CHECK(value.template get_as<Value>().value_ == 2);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 0);
+        CHECK(Value::numMoves == 1);
+    }
+    SECTION("can move values with hold()")
+    {
+        {
+            auto value = TestType::template erase_type<Value>(1u);
+            auto other = Value{ 2 };
+
+            value.template hold<Value>(std::move(other));
+
+            CHECK(value.template get_as<Value>().value_ == 2);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 0);
+        CHECK(Value::numMoves == 1);
+    }
+    SECTION("can copy values with hold()")
+    {
+        {
+            auto value = TestType::template erase_type<Value>(1u);
+            Value other = Value{ 2 };
+            value.template hold<Value>(other);
+
+            CHECK(value.template get_as<Value>().value_ == 2);
+        }
+
+        Value::test();
+        CHECK(Value::numConstructs == 2);
+        CHECK(Value::numCopies == 1);
+        CHECK(Value::numMoves == 0);
+    }
+}


### PR DESCRIPTION
- Added new class (`ErasedType`) which is able to handle type erasure in a performant(-ish) way and can be used to create a heterogeneous map without global data
  - Note that it is also compliant (I spent many hours ensuring that correct usage does not violate strict aliasing or lifetime rules)
  - Note also that I probably missed something and would love to learn more if the above statement is incorrect
- Added tests for this class