### PR TITLE
Remove unnecessary dependency from oki_container.h

### DIFF
--- a/src/oki/util/oki_container.h
+++ b/src/oki/util/oki_container.h
@@ -1,8 +1,6 @@
 #ifndef OKI_CONTAINER_H
 #define OKI_CONTAINER_H
 
-#include "oki/util/oki_handle_gen.h"
-
 #include <algorithm>
 #include <cstdint>
 #include <iterator>


### PR DESCRIPTION
Removed a header include I accidentally left in the initial commit.