### PR TITLE
Add emplace() to AssocSortedVector and rework test structure

### DIFF
--- a/test/oki_test_type_erasure.cpp
+++ b/test/oki_test_type_erasure.cpp
@@ -1,80 +1,13 @@
 #include "oki/util/oki_type_erasure.h"
 #include "oki/oki_handle.h"
 
+#include "oki_test_util.h"
+
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_template_test_macros.hpp"
 
 #include <cstdint>
 #include <utility>
-
-namespace test_helper
-{
-    struct ObjHelper
-    {
-        static inline std::size_t
-            numConstructs = 0,
-            numCopies = 0,
-            numMoves = 0,
-            numDestructs = 0;
-
-        ObjHelper()
-            : value_(0)
-        {
-            ++numConstructs;
-        }
-
-        ObjHelper(std::size_t value)
-            : value_(value)
-        {
-            ++numConstructs;
-        }
-
-        ObjHelper(const ObjHelper& that)
-            : value_(that.value_)
-        {
-            ++numConstructs;
-            ++numCopies;
-        }
-
-        ObjHelper(ObjHelper&& that)
-            : value_(that.value_)
-        {
-            ++numConstructs;
-            ++numMoves;
-        }
-
-        ~ObjHelper()
-        {
-            ++numDestructs;
-        }
-
-        ObjHelper& operator=(const ObjHelper& that)
-        {
-            ++numCopies;
-            value_ = that.value_;
-            return (*this);
-        }
-
-        ObjHelper& operator=(ObjHelper&& that)
-        {
-            ++numMoves;
-            value_ = that.value_;
-            return (*this);
-        }
-
-        static void reset()
-        {
-            numConstructs = numCopies = numMoves = numDestructs = 0;
-        }
-
-        static void test()
-        {
-            CHECK(numConstructs == numDestructs);
-        }
-
-        std::size_t value_;
-    };
-}
 
 using Value = test_helper::ObjHelper;
 

--- a/test/oki_test_util.h
+++ b/test/oki_test_util.h
@@ -1,0 +1,72 @@
+#include "catch2/catch_test_macros.hpp"
+
+#include <cstdint>
+
+namespace test_helper
+{
+    struct ObjHelper
+    {
+        static inline std::size_t
+            numConstructs = 0,
+            numCopies = 0,
+            numMoves = 0,
+            numDestructs = 0;
+
+        ObjHelper()
+            : value_(0)
+        {
+            ++numConstructs;
+        }
+
+        ObjHelper(std::size_t value)
+            : value_(value)
+        {
+            ++numConstructs;
+        }
+
+        ObjHelper(const ObjHelper& that)
+            : value_(that.value_)
+        {
+            ++numConstructs;
+            ++numCopies;
+        }
+
+        ObjHelper(ObjHelper&& that)
+            : value_(that.value_)
+        {
+            ++numConstructs;
+            ++numMoves;
+        }
+
+        ~ObjHelper()
+        {
+            ++numDestructs;
+        }
+
+        ObjHelper& operator=(const ObjHelper& that)
+        {
+            ++numCopies;
+            value_ = that.value_;
+            return (*this);
+        }
+
+        ObjHelper& operator=(ObjHelper&& that)
+        {
+            ++numMoves;
+            value_ = that.value_;
+            return (*this);
+        }
+
+        static void reset()
+        {
+            numConstructs = numCopies = numMoves = numDestructs = 0;
+        }
+
+        static void test()
+        {
+            CHECK(numConstructs == numDestructs);
+        }
+
+        std::size_t value_;
+    };
+}


### PR DESCRIPTION
- Added an `emplace()` method to in-place construct a value in an `AssocSortedVector`
  - Reworked `insert()` to use this method as well
- Added lifetime tests to `AssocSortedVector`
- Factored `test_helper::ObjHelper` into its own header file for use in other tests