### PR TITLE
Allow catch2 to print incorrect lifetime values

### DIFF
--- a/test/oki_test_util.h
+++ b/test/oki_test_util.h
@@ -77,15 +77,15 @@ namespace test_helper
 
             if (constr)
             {
-                CHECK(numConstructs == constr);
+                CHECK(numConstructs == constr.value());
             }
             if (copies)
             {
-                CHECK(numCopies == copies);
+                CHECK(numCopies == copies.value());
             }
             if (moves)
             {
-                CHECK(numMoves == moves);
+                CHECK(numMoves == moves.value());
             }
         }
 


### PR DESCRIPTION
Quick amendment (I deleted the last branch too hastily). Allows catch2 to print incorrect values on test failure instead of `{?}` (unknown internals of a `std::optional<>`).