### PR TITLE
Add component storage and update oki_ecs.h

### DIFF
--- a/src/oki/oki_component.h
+++ b/src/oki/oki_component.h
@@ -1,0 +1,455 @@
+#include "oki/oki_handle.h"
+#include "oki/util/oki_container.h"
+#include "oki/util/oki_handle_gen.h"
+#include "oki/util/oki_type_erasure.h"
+
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <unordered_map>
+
+namespace oki
+{
+    /*
+     * Opaque class representing an entity (the 'E' in ECS). This object is
+     * provided by and used in conjunction with the ComponentManager to relate
+     * components to each other, allowing composition.
+     */
+    class Entity
+    {
+    public:
+        using HandleType = oki::Handle;
+
+    private:
+        HandleType handle_ = oki::intl_::get_invalid_handle_constant();
+
+        friend class ComponentManager;
+    };
+
+    /*
+     * Class responsible for storing components and relating them to entities
+     * and, by extension, each other.
+     *
+     * This is the 'core' ECS behavior (it accounts for the data: 'E' and 'C',
+     * and the 'S' is mostly handled by the caller because it is code).
+     */
+    class ComponentManager
+    {
+    public:
+        ComponentManager() = default;
+        ComponentManager(const ComponentManager&) = default;
+        ComponentManager(ComponentManager&&) = default;
+        ~ComponentManager() = default;
+
+        /*
+         * Creates and returns an entity with which one can add, remove
+         * and retrieve components.
+         *
+         * This is how composition is achieved: doing so tells the
+         * ComponentManager how different components relate to each other.
+         */
+        oki::Entity create_entity()
+        {
+            oki::Entity entity;
+            entity.handle_ = handGen_.create_handle();
+
+            return entity;
+        }
+
+        /*
+         * Deletes the entity handle (potentially allowing reuse) but DOES NOT
+         * erase the entities that were associated with this entity.
+         *
+         * (The ability to do so comes with significant cost due to the type
+         * erasure and may be added in the future, but not now.)
+         *
+         * Returns whether the deletion was successful (which is a no-op
+         * by default).
+         */
+        bool destroy_entity(oki::Entity entity)
+        {
+            return handGen_.destroy_handle(entity.handle_);
+        }
+
+        /*
+         * Adds a component of type Type if one was NOT already bound to this
+         * entity and returns std::pair, where .first is a reference to the new
+         * component and .second indicates whether the insertion took place.
+         *
+         * Constructs the component in-place by forwarding the 0 or more
+         * supplied arguments to the constructor of Type.
+         */
+        template <typename Type, typename... Args>
+        std::pair<Type&, bool> emplace_component(oki::Entity entity, Args&&... args)
+        {
+            auto& cont = this->get_or_create_cont_<Type>();
+
+            auto [valIter, success] = cont.emplace(
+                entity.handle_,
+                std::forward<Args>(args)...
+            );
+
+            return { valIter->second, success };
+        }
+
+        /*
+         * Adds a component if one with same type was NOT already bound to this
+         * entity, and returns std::pair where .first is a reference to the new
+         * component and .second indicates whether the insertion took place.
+         *
+         * Deduces the component type and forwards the incoming value.
+         */
+        template <typename InsertType>
+        auto bind_component(oki::Entity entity, InsertType&& value)
+        {
+            return this->emplace_component<std::decay_t<InsertType>>(
+                entity,
+                std::forward<InsertType>(value)
+            );
+        }
+
+        /*
+         * Guarantees that the entity has a component matching the incoming value
+         * and type by either creating a new one or assigning the existing value.
+         *
+         * Returns a std::pair where .first is a reference to the component in
+         * question and .second indicates whether the component is new (true)
+         * or old (false).
+         *
+         * Deduces the component type and forwards the incoming value.
+         */
+        template <typename InsertType>
+        auto bind_or_assign_component(oki::Entity entity, InsertType&& value)
+        {
+            using Type = std::decay_t<InsertType>;
+            auto& cont = this->get_or_create_cont_<Type>();
+
+            auto [valIter, success] = cont.insert_or_assign(
+                entity.handle_,
+                std::forward<InsertType>(value)
+            );
+
+            return std::pair<Type&, bool>{ valIter->second, success };
+        }
+
+        /*
+         * In-place constructs a component of type Type bound to the provided
+         * entity, assuming (without checking) that there is not already a
+         * component of the same type bound.
+         *
+         * OKI does not support adding multiple components of the same
+         * type to one entity and its behavior is not formally supported in
+         * this state.
+         *
+         * Forwards the supplied arguments to the constructor of Type.
+         */
+        template <typename Type, typename... Args>
+        Type& emplace_component_unchecked(oki::Entity entity, Args&&... args)
+        {
+            auto& cont = this->get_or_create_cont_<Type>();
+            auto iter = cont.emplace_unchecked(
+                entity.handle_,
+                std::forward<Args>(args)...
+            );
+
+            return iter->second;
+        }
+
+        /*
+         * Binds a component to an entity, assuming (without checking) that
+         * there is not already a component of the same type bound.
+         *
+         * OKI does not support adding multiple components of the same
+         * type to one entity and its behavior is not formally supported in
+         * this state.
+         *
+         * Deduces the type and forwards the incoming value to the constructor.
+         */
+        template <typename InsertType>
+        auto& bind_component_unchecked(oki::Entity entity, InsertType&& value)
+        {
+            return this->emplace_component_unchecked<std::decay_t<InsertType>>(
+                entity,
+                std::forward<InsertType>(value)
+            );
+        }
+
+        /*
+         * Attempts to unbind a component from the provided entity and
+         * call its destructor, then returns whether or not a component
+         * existed and was deleted.
+         */
+        template <typename Type>
+        bool remove_component(oki::Entity entity)
+        {
+            return this->call_on_cont_checked_<Type, bool>([=](auto& container) {
+                return container.erase(entity.handle_);
+            }, false);
+        }
+
+        /*
+         * Erases all components of a given type.
+         */
+        template <typename Type>
+        void erase_components()
+        {
+            this->call_on_cont_checked_<Type>([](auto& container) {
+                container.clear();
+            });
+        }
+
+        /*
+         * Erases all components.
+         */
+        void erase_components()
+        {
+            data_.clear();
+        }
+
+        /*
+         * Retrieves a reference to component of type Type from the provided
+         * entity, assuming (without checking) that this entity has a component
+         * of that type.
+         *
+         * Components are owned by the ComponentManager and this reference is
+         * valid only until a new component of this type is added (very likely
+         * longer but OKI does not formally support this).
+         */
+        template <typename Type>
+        Type& get_component(oki::Entity entity)
+        {
+            return this->get_cont_<Type>().find(entity.handle_)->second;
+        }
+
+        /*
+         * If the entity has a component of this type, returns a pointer thereto;
+         * otherwise, returns nullptr.
+         *
+         * Components are owned by the ComponentManager and this pointer is
+         * valid only until a new component of this type is added (very likely
+         * longer but OKI does not formally support this).
+         */
+        template <typename Type>
+        Type* get_component_checked(oki::Entity entity)
+        {
+            return this->call_on_cont_checked_<Type, Type*>([=](auto& container) {
+                auto compIter = container.find(entity.handle_);
+
+                return (compIter != container.end())
+                     ? std::addressof(compIter->second)
+                     : nullptr;
+            }, nullptr);
+        }
+
+        /*
+         * Syntactic sugar for getting multiple components from an entity.
+         * (Looks good with structured bindings!)
+         */
+        template <typename... Types>
+        std::tuple<Types&...> get_components(oki::Entity entity)
+        {
+            return std::tie(this->get_component<Types>(entity)...);
+        }
+
+        /*
+         * Syntactic sugar for getting multiple components (checked) from
+         * an entity.
+         */
+        template <typename... Types>
+        std::tuple<Types*...> get_components_checked(oki::Entity entity)
+        {
+            return { this->get_component_checked<Types>(entity)... };
+        }
+
+        /*
+         * Seeks a component of this type that is bound to provided entity
+         * and returns whether one was found.
+         */
+        template <typename Type>
+        bool has_component(oki::Entity entity) const noexcept
+        {
+            return this->call_on_cont_checked_<Type, bool>([=](auto& container) {
+                return container.contains(entity.handle_);
+            }, false);
+        }
+
+        /*
+         * The primary reason to use an ECS architecture, this provides
+         * the ability to iterate over entities' components.
+         *
+         * The input functor func() will be called with the following
+         * parameters for each matching entity:
+         *   - An oki::Entity representing the components' owner
+         *   - A reference to each of the bound components whose types
+         *      are specified in Types..., in the order provided
+         */
+        template <typename... Types, typename Callback>
+        Callback for_each(Callback func)
+        {
+            /*
+             * Design note: we could just use this->get_or_create_cont_()
+             * instead but this is more efficient and has no suprise
+             * allocations. Failing out of this function is "free".
+             */
+            [&](auto... contPtrs) {
+                // If any containers are missing, exit early
+                if ((!contPtrs || ...))
+                {
+                    return;
+                }
+
+                // Otherwise, proceed as usual
+                this->component_intersection_(func, *contPtrs...);
+            }(this->try_get_cont_<Types>()...);
+
+            return func;
+        }
+
+        /*
+         * Allocates enough space for n components of type Type.
+         *
+         * (Internal tip: creates the relevant container if it does not
+         * already exist, which can optimize the first component bind of
+         * type Type.)
+         */
+        template <typename Type>
+        void reserve_components(std::size_t n)
+        {
+            auto& container = this->get_or_create_cont_<Type>();
+            container.reserve(n);
+        }
+
+        /*
+         * Returns the number of components of a given type.
+         */
+        template <typename Type>
+        std::size_t num_components() const
+        {
+            return this->call_on_cont_checked_<Type, std::size_t>(
+            [](auto& container) {
+                return container.size();
+            }, 0);
+        }
+
+    private:
+        using HandleType = oki::Entity::HandleType;
+
+        template <typename Type>
+        using Container = oki::intl_::AssocSortedVector<
+            HandleType,
+            std::decay_t<Type>
+        >;
+
+        using ErasedContainer = oki::intl_::OptimalErasedType<Container<long>>;
+
+        std::unordered_map<
+            oki::intl_::TypeIndex,
+            ErasedContainer
+        > data_;
+
+        oki::intl_::DefaultHandleGenerator<oki::Entity::HandleType> handGen_;
+
+        template <typename Type>
+        Container<Type>& create_cont_()
+        {
+            auto [iter, _] = data_.emplace(
+                oki::intl_::get_type<Type>(),
+                ErasedContainer::erase_type<Container<Type>>()
+            );
+
+            return iter->second;
+        }
+
+        template <typename Type>
+        Container<Type>& get_or_create_cont_()
+        {
+            auto iter = data_.find(oki::intl_::get_type<Type>());
+
+            if (iter == data_.end())
+            {
+                iter = data_.emplace_hint(
+                    iter,
+                    oki::intl_::get_type<Type>(),
+                    ErasedContainer::erase_type<Container<Type>>()
+                );
+            }
+
+            return iter->second.template get_as<Container<Type>>();
+        }
+
+        template <typename Type>
+        Container<Type>& get_cont_()
+        {
+            auto iter = data_.find(oki::intl_::get_type<Type>());
+
+            return iter->second.template get_as<Container<Type>>();
+        }
+
+        template <typename Type>
+        Container<Type>* try_get_cont_()
+        {
+            auto iter = data_.find(oki::intl_::get_type<Type>());
+
+            return iter != data_.end()
+                 ? &iter->second.template get_as<Container<Type>>()
+                 : nullptr;
+        }
+
+        template <typename Type, typename ReturnType,
+                  typename Callback, typename DefaultRet>
+        ReturnType call_on_cont_checked_(Callback func, DefaultRet defaultValue) const
+        {
+            static_assert(std::is_convertible_v<DefaultRet, ReturnType>);
+
+            auto contIter = data_.find(oki::intl_::get_type<Type>());
+            if (contIter != data_.cend())
+            {
+                return func(contIter->second.template get_as<Container<Type>>());
+            }
+
+            return defaultValue;
+        }
+
+        template <typename Type, typename ReturnType,
+                  typename Callback, typename DefaultRet>
+        ReturnType call_on_cont_checked_(Callback func, DefaultRet defaultValue)
+        {
+            // Trying to do this with two const_casts and a std::as_const was worse
+            // than just duplicating this code
+            static_assert(std::is_convertible_v<DefaultRet, ReturnType>);
+
+            auto contIter = data_.find(oki::intl_::get_type<Type>());
+            if (contIter != data_.end())
+            {
+                return func(contIter->second.template get_as<Container<Type>>());
+            }
+
+            return defaultValue;
+        }
+
+        template <typename Type, typename Callback>
+        void call_on_cont_checked_(Callback func)
+        {
+            this->call_on_cont_checked_<Type, int>([&](auto& container) -> int {
+                func(container);
+                return 0;
+            }, 0);
+        }
+
+        template <typename Callback, typename... Containers>
+        static void component_intersection_(Callback& func, Containers&... conts)
+        {
+            oki::intl_::variadic_set_intersection(
+                [&](auto& val, auto&... vals) {
+                    // Unfortunate oversight on my part
+                    oki::Entity entity;
+                    entity.handle_ = val.first;
+
+                    func(entity, val.second, vals.second...);
+                },
+                std::make_pair(conts.begin(), conts.end())...
+            );
+        }
+    };
+}

--- a/src/oki/oki_ecs.h
+++ b/src/oki/oki_ecs.h
@@ -1,7 +1,6 @@
 #ifndef OKI_ECS_H
 #define OKI_ECS_H
 
-#include "oki/util/oki_handle_gen.h"
-#include "oki/oki_handle.h"
+#include "oki/oki_component.h"
 
 #endif // OKI_ECS_H

--- a/src/oki/util/oki_container.h
+++ b/src/oki/util/oki_container.h
@@ -275,7 +275,7 @@ namespace oki
                     {
                         static_assert(sizeof...(Args) == 1);
                         static_assert(std::is_assignable_v<
-                            Type,
+                            Type&,
                             std::tuple_element_t<0, std::decay_t<decltype(args)>>
                         >);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,11 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Catch2)
 
-add_executable(oki_unit oki_test_handle.cpp oki_test_container.cpp oki_test_type_erasure.cpp)
+add_executable(oki_unit
+    oki_test_handle.cpp
+    oki_test_container.cpp
+    oki_test_type_erasure.cpp
+    oki_test_component.cpp
+)
 target_include_directories(oki_unit PRIVATE "../src/")
 target_link_libraries(oki_unit PRIVATE Catch2::Catch2WithMain)

--- a/test/oki_test_component.cpp
+++ b/test/oki_test_component.cpp
@@ -1,0 +1,422 @@
+#include "oki/oki_component.h"
+
+#include "oki_test_util.h"
+
+#include "catch2/catch_test_macros.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <set>
+
+using Value = test_helper::ObjHelper;
+using TestType = oki::ComponentManager;
+
+TEST_CASE("ComponentManager")
+{
+    oki::ComponentManager compMan;
+    auto entity = compMan.create_entity();
+
+    SECTION("can add and retrieve component")
+    {
+        auto [comp, success] = compMan.bind_component(entity, 0);
+
+        REQUIRE(comp == 0);
+        REQUIRE(success);
+
+        REQUIRE(compMan.get_component<int>(entity) == 0);
+        REQUIRE(*compMan.get_component_checked<int>(entity) == 0);
+        REQUIRE(compMan.has_component<int>(entity));
+    }
+    SECTION("rejects already present components in bind_component()")
+    {
+        CHECK(compMan.bind_component(entity, 0).second);
+
+        auto [comp, success] = compMan.bind_component(entity, 1);
+
+        REQUIRE(comp == 0);
+        REQUIRE_FALSE(success);
+    }
+    SECTION("can update component with reference from bind_component()")
+    {
+        compMan.bind_component(entity, 0);
+
+        auto [comp, success] = compMan.bind_component(entity, 1);
+        comp = 2;
+
+        CHECK(compMan.get_component<int>(entity) == 2);
+    }
+    SECTION("can update component with reference from bind_component_unchecked()")
+    {
+        compMan.bind_component(entity, 0);
+
+        auto& comp = compMan.bind_component_unchecked(entity, 1);
+        comp = 2;
+
+        CHECK(compMan.get_component<int>(entity) == 2);
+    }
+    SECTION("can update component with get_component()")
+    {
+        compMan.bind_component(entity, 0);
+
+        auto& intComp = compMan.get_component<int>(entity);
+        intComp = 2;
+
+        int* intPtr = compMan.get_component_checked<int>(entity);
+        REQUIRE((intPtr && *intPtr == 2));
+
+        *intPtr = 3;
+        REQUIRE(intComp == 3);
+    }
+    SECTION("can update component with bind_or_assign_component()")
+    {
+        compMan.bind_component(entity, 0);
+        compMan.bind_or_assign_component(entity, 1);
+
+        REQUIRE(compMan.get_component<int>(entity) == 1);
+    }
+    SECTION("can bind multiple components to one entity")
+    {
+        compMan.bind_component(entity, 0);
+        compMan.bind_component(entity, 1.5f);
+        compMan.bind_component(entity, std::string{ "wowie" });
+
+        REQUIRE(compMan.get_component<int>(entity) == 0);
+        REQUIRE(compMan.get_component<float>(entity) == 1.5);
+        REQUIRE(compMan.get_component<std::string>(entity) == "wowie");
+
+        REQUIRE(compMan.has_component<int>(entity));
+        REQUIRE(compMan.has_component<float>(entity));
+        REQUIRE(compMan.has_component<std::string>(entity));
+    }
+    SECTION("can bind components to multiple entities")
+    {
+        auto entity2 = compMan.create_entity();
+
+        compMan.bind_component(entity, 0);
+        compMan.bind_component(entity2, 1);
+
+        REQUIRE(compMan.get_component<int>(entity) == 0);
+        REQUIRE(compMan.get_component<int>(entity2) == 1);
+
+        REQUIRE(compMan.has_component<int>(entity));
+        REQUIRE(compMan.has_component<int>(entity2));
+    }
+    SECTION("can retrieve and update multiple components at once")
+    {
+        compMan.bind_component(entity, 0);
+        compMan.bind_component(entity, 1.5f);
+        compMan.bind_component(entity, std::string{ "wowie" });
+
+        auto [i, f, s] = compMan.get_components<
+            int, float, std::string
+        >(entity);
+
+        REQUIRE(i == 0);
+        REQUIRE(f == 1.5f);
+        REQUIRE(s == "wowie");
+
+        i = 2;
+        f = 4.f;
+        s = "wowza";
+
+        REQUIRE(compMan.get_component<int>(entity) == 2);
+        REQUIRE(compMan.get_component<float>(entity) == 4.f);
+        REQUIRE(compMan.get_component<std::string>(entity) == "wowza");
+    }
+    SECTION("can get a mixture of present and not present components")
+    {
+        auto entity2 = compMan.create_entity();
+        compMan.bind_component(entity2, 'z');
+
+        compMan.bind_component(entity, 0);
+        compMan.bind_component(entity, 1.5f);
+
+        auto [i, c, f, s] = compMan.get_components_checked<
+            int, char, float, std::string
+        >(entity);
+
+        REQUIRE((i && *i == 0));
+        REQUIRE_FALSE(c);
+        REQUIRE((f && *f == 1.5));
+        REQUIRE_FALSE(s);
+    }
+    SECTION("rejects absent component [container is missing]")
+    {
+        CHECK_FALSE(compMan.get_component_checked<int>(entity));
+        CHECK_FALSE(compMan.has_component<int>(entity));
+    }
+    SECTION("rejects absent component [entity does not have this type]")
+    {
+        auto entity2 = compMan.create_entity();
+        compMan.bind_component(entity2, 1);
+
+        CHECK_FALSE(compMan.get_component_checked<int>(entity));
+        CHECK_FALSE(compMan.has_component<int>(entity));
+    }
+    SECTION("can remove present component")
+    {
+        compMan.bind_component(entity, 1);
+
+        REQUIRE(compMan.remove_component<int>(entity));
+
+        REQUIRE_FALSE(compMan.get_component_checked<int>(entity));
+        REQUIRE_FALSE(compMan.has_component<int>(entity));
+    }
+    SECTION("does not remove absent component [container is missing]")
+    {
+        CHECK_FALSE(compMan.remove_component<int>(entity));
+    }
+    SECTION("does not remove absent component [entity does not have this type]")
+    {
+        auto entity2 = compMan.create_entity();
+        compMan.bind_component(entity2, 1);
+
+        CHECK_FALSE(compMan.remove_component<int>(entity));
+
+        auto comp2 = compMan.get_component_checked<int>(entity2);
+        CHECK((comp2 && *comp2 == 1));
+    }
+    SECTION("can remove all elements of type")
+    {
+        auto entity2 = compMan.create_entity();
+        compMan.bind_component(entity, 1);
+        compMan.bind_component(entity2, 2);
+
+        compMan.erase_components<int>();
+
+        REQUIRE_FALSE(compMan.get_component_checked<int>(entity));
+        REQUIRE_FALSE(compMan.get_component_checked<int>(entity2));
+
+        REQUIRE_FALSE(compMan.has_component<int>(entity));
+        REQUIRE_FALSE(compMan.has_component<int>(entity2));
+    }
+    SECTION("can iterate over and update one component type")
+    {
+        constexpr unsigned NUM_VALS = 15;
+
+        int expectedVals[NUM_VALS] = { 0 };
+        for (unsigned i = 0; i != NUM_VALS; ++i)
+        {
+            unsigned value = i * 2;
+
+            compMan.bind_component(compMan.create_entity(), value);
+            expectedVals[i] = value;
+        }
+
+        std::set<int> values;
+        compMan.for_each<unsigned>([&](const oki::Entity ent, unsigned& val) {
+            values.insert(val);
+            val = 0;
+        });
+
+        REQUIRE(std::equal(values.begin(), values.end(), expectedVals));
+
+        compMan.for_each<unsigned>([&](const oki::Entity ent, const unsigned val) {
+            REQUIRE(val == 0);
+        });
+    }
+    SECTION("can iterate over several component types")
+    {
+        auto e1 = compMan.create_entity();
+        auto e2 = compMan.create_entity();
+        auto e3 = compMan.create_entity();
+        auto e4 = compMan.create_entity();
+
+        compMan.bind_component(e1, 1);
+        compMan.bind_component(e1, 1.f);
+        compMan.bind_component(e1, '1');
+
+        compMan.bind_component(e2, 2);
+        compMan.bind_component(e2, '2');
+
+        compMan.bind_component(e3, 3.f);
+        compMan.bind_component(e3, '3');
+        compMan.bind_component(e3, 3ull);
+
+        compMan.bind_component(e4, 4);
+        compMan.bind_component(e4, 4.f);
+        compMan.bind_component(e4, '4');
+
+        {
+            std::set<int> values;
+            compMan.for_each<int, float, char>([&](auto ent, int i, auto...) {
+                values.insert(i);
+            });
+
+            int expectedVals[2] = { 1, 4 };
+            REQUIRE(values.size() == 2);
+            REQUIRE(std::equal(values.begin(), values.end(), expectedVals));
+        }
+        {
+            std::set<int> values;
+            compMan.for_each<int, char>([&](auto ent, int i, auto...) {
+                values.insert(i);
+            });
+
+            int expectedVals[4] = { 1, 2, 4 };
+            REQUIRE(values.size() == 3);
+            REQUIRE(std::equal(values.begin(), values.end(), expectedVals));
+        }
+        {
+            std::set<unsigned long long> values;
+            compMan.for_each<unsigned long long>([&](auto ent, unsigned long long i) {
+                values.insert(i);
+            });
+
+            unsigned long long expectedVals[1] = { 3 };
+            REQUIRE(std::equal(values.begin(), values.end(), expectedVals));
+        }
+    }
+    SECTION("can check missing containers in for_each()")
+    {
+        compMan.for_each<int>([](auto...) {
+            // This should never be called (no components)
+            REQUIRE(false);
+        });
+    }
+    SECTION("reserve_components() does not increase num_components()")
+    {
+        compMan.reserve_components<int>(10);
+
+        CHECK_FALSE(compMan.num_components<int>());
+    }
+    SECTION("reserve_components() does not decrease num_components()")
+    {
+        compMan.bind_component(entity, 0);
+        compMan.reserve_components<int>(0);
+
+        CHECK(compMan.num_components<int>() == 1);
+        CHECK(compMan.has_component<int>(entity));
+    }
+    SECTION("can destroy an entity")
+    {
+        // Basically does nothing at the moment
+        CHECK(compMan.destroy_entity(entity));
+    }
+
+    SECTION("(lifetime management)")
+    {
+        Value::reset();
+
+        auto test_lifetime =
+        [](auto memFunc, std::size_t value, auto constr, auto copies, auto moves)
+        {
+            {
+                oki::ComponentManager tempCompMan;
+                auto ent = tempCompMan.create_entity();
+
+                memFunc(tempCompMan, ent);
+
+                REQUIRE(tempCompMan.get_component<Value>(ent).value_ == value);
+            }
+
+            Value::test(constr, copies, moves);
+        };
+
+        SECTION("can insert and retrieve components")
+        {
+            test_lifetime([](TestType& manager, oki::Entity entity) {
+                CHECK(manager.bind_component(entity, Value{ 1 }).second);
+            }, 1, 2, 0, 1);
+        }
+        SECTION("can emplace components")
+        {
+            test_lifetime([](TestType& manager, oki::Entity entity) {
+                CHECK(manager.emplace_component<Value>(entity, 1u).second);
+            }, 1, 1, 0, 0);
+        }
+        SECTION("can default construct components")
+        {
+            test_lifetime([](TestType& manager, oki::Entity entity) {
+                CHECK(manager.emplace_component<Value>(entity).second);
+            }, 0, 1, 0, 0);
+        }
+        SECTION("can move insert components")
+        {
+            test_lifetime([](TestType& manager, oki::Entity entity) {
+                Value value{ 1 };
+                manager.bind_component(entity, std::move(value));
+            }, 1, 2, 0, 1);
+        }
+        SECTION("can copy insert components")
+        {
+            test_lifetime([](TestType& manager, oki::Entity entity) {
+                Value value{ 1 };
+                manager.bind_component(entity, value);
+            }, 1, 2, 1, 0);
+        }
+        SECTION("can move assign components")
+        {
+            test_lifetime([](TestType& manager, oki::Entity entity) {
+                manager.emplace_component<Value>(entity);
+                auto [comp, success] = manager.bind_or_assign_component(
+                    entity,
+                    Value{ 1 }
+                );
+
+                CHECK_FALSE(success);
+            }, 1, 2, 0, 1);
+        }
+        SECTION("can copy assign components")
+        {
+            test_lifetime([](TestType& manager, oki::Entity entity) {
+                manager.emplace_component<Value>(entity);
+
+                Value value{ 1 };
+                auto [comp, success] = manager.bind_or_assign_component(
+                    entity,
+                    value
+                );
+
+                CHECK_FALSE(success);
+            }, 1, 2, 1, 0);
+        }
+        SECTION("calls destructor on removed components")
+        {
+            {
+                auto manager = TestType();
+                auto entity = manager.create_entity();
+
+                manager.emplace_component<Value>(entity);
+                manager.remove_component<Value>(entity);
+
+                CHECK(Value::numConstructs == 1);
+                CHECK(Value::numDestructs == 1);
+            }
+
+            Value::test();
+        }
+        SECTION("calls destructor on erased components")
+        {
+            {
+                auto manager = TestType();
+                auto entity = manager.create_entity();
+
+                manager.emplace_component<Value>(entity);
+                manager.erase_components<Value>();
+
+                CHECK(Value::numConstructs == 1);
+                CHECK(Value::numDestructs == 1);
+            }
+
+            Value::test();
+        }
+        SECTION("calls destructor on erased components (type erased)")
+        {
+            {
+                auto manager = TestType();
+                auto entity = manager.create_entity();
+
+                manager.emplace_component<Value>(entity);
+                manager.erase_components();
+
+                CHECK(Value::numConstructs == 1);
+                CHECK(Value::numDestructs == 1);
+            }
+
+            Value::test();
+        }
+    }
+}


### PR DESCRIPTION
- Added `Entity` and `ComponentManager`, the core ECS classes
- Added RTTI to `oki_type_erasure.h`
- Made quick fix to assignability check in `AssocSortedVector` (`int` is not assignable but `int&` is)
- Added tests for `ComponentManager`