### PR TITLE
Fix out-of-bounds in variadic_set_intersection()

### DIFF
--- a/src/oki/util/oki_container.h
+++ b/src/oki/util/oki_container.h
@@ -342,6 +342,11 @@ namespace oki
         {
             namespace helper = oki::intl_::helper_;
 
+            if (((iterPairs.first == iterPairs.second) || ...))
+            {
+                return func;
+            }
+
             // This is essentially the merge join algorithm, optimized for cache-coherence
             auto max = helper::get_first_key(iterPairs...);
             while (true)


### PR DESCRIPTION
Fix an out-of-bounds memory access that was previously allowed to slip through.

Note that it would have been sufficient to only check the first pair (all others would be verified by `get_first_key()`) but this shouldn't make a noticeable difference.