### PR TITLE
Refactor type erasure for flexibility

### DIFF
--- a/src/oki/util/oki_type_erasure.h
+++ b/src/oki/util/oki_type_erasure.h
@@ -33,42 +33,33 @@ namespace oki
          * Per the assumption that the caller *knows the type*, there is NO
          * TYPE CHECKING for ANY operation. It is optimized for performance and
          * is able to function without RTTI. Such is the benefit over std::any.
+         *
+         * This version in particular stores move-only types.
          */
         template <std::size_t Size, std::size_t Align>
-        class ErasedType
+        class MovableErasedType
         {
         public:
-            ErasedType(const ErasedType<Size, Align>& that)
+            MovableErasedType(MovableErasedType<Size, Align>&& that)
                 : budgetVtable_(that.budgetVtable_)
             {
-                this->budgetVtable_(*this, &that, Operation::COPY_CONSTR);
+                this->vtable_dispatch_(&that, Operation::MOVE_CONSTR);
             }
 
-            ErasedType(ErasedType<Size, Align>&& that)
-                : budgetVtable_(that.budgetVtable_)
+            ~MovableErasedType()
             {
-                this->budgetVtable_(*this, &that, Operation::MOVE_CONSTR);
-            }
-
-            ~ErasedType()
-            {
-                this->budgetVtable_(*this, nullptr, Operation::DESTROY);
+                this->vtable_dispatch_(nullptr, Operation::DESTROY);
             }
 
             /*
              * As an example of the above, there is no guarantee that the other
-             * ErasedType<> holds a type that is equivalent to this one. It falls
-             * on the caller to be sure they're correct.
+             * MovableErasedType<> holds a type that is equivalent to this one.
+             * It falls on the caller to be sure they're correct.
              */
-            ErasedType<Size, Align>& operator=(const ErasedType<Size, Align>& that)
+            MovableErasedType<Size, Align>& operator=(
+                MovableErasedType<Size, Align>&& that)
             {
-                this->budgetVtable_(*this, &that, Operation::COPY_ASSIGN);
-                return *this;
-            }
-
-            ErasedType<Size, Align>& operator=(ErasedType<Size, Align>&& that)
-            {
-                this->budgetVtable_(*this, &that, Operation::MOVE_ASSIGN);
+                this->vtable_dispatch_(&that, Operation::MOVE_ASSIGN);
                 return *this;
             }
 
@@ -94,7 +85,7 @@ namespace oki
              * Takes a value matching the underlying type and assigns
              * it to the internal object with perfect forwarding.
              *
-             * This should be preferred over assigning the ErasedType<>.
+             * This should be preferred over assigning the MovableErasedType<>.
              */
             template <typename Type, typename InsertType>
             void hold(InsertType&& value)
@@ -103,50 +94,96 @@ namespace oki
             }
 
             /*
-             * Copy-assigns the value in the provided ErasedType<> to the
-             * one in this instance.
+             * Move-assigns the value in the provided MovableErasedType<> to
+             * the one in this instance.
              *
              * Should be preferred over assignment.
              */
             template <typename Type>
-            void copy_from(const ErasedType<Size, Align>& that)
+            void move_from(MovableErasedType<Size, Align>&& that)
             {
-                this->hold<Type>(that.get_as<Type>());
-            }
-
-            /*
-             * Move-assigns the value in the provided ErasedType<> to the
-             * one in this instance.
-             *
-             * Should be preferred over assignment.
-             */
-            template <typename Type>
-            void move_from(ErasedType<Size, Align>&& that)
-            {
-                this->hold<Type>(std::move(that.get_as<Type>()));
-            }
-
-            /*
-             * Creates an ErasedType<> instace holding a value of type Type,
-             * constructing one in-place by perfectly forwarding the variadic
-             * arguments.
-             */
-            template <typename Type, typename... Args>
-            static ErasedType<Size, Align> erase_type(Args&&... args)
-            {
-                ErasedType<Size, Align> ret;
-
                 if constexpr (is_small_buffered<Type>::value)
                 {
-                    new (ret.storage_.buf_) Type{ std::forward<Args>(args)... };
+                    this->hold<Type>(std::move(that.get_as<Type>()));
                 }
                 else
                 {
-                    ret.storage_.ptr_ = new Type{ std::forward<Args>(args)... };
+                    std::swap(storage_.ptr_, that.storage_.ptr_);
                 }
-                ret.budgetVtable_ = erased_ops_<Type>;
+            }
+
+            /*
+             * Creates a MovableErasedType<> instace holding a value of type
+             * Type, constructing one in-place by perfectly forwarding the
+             * variadic arguments.
+             */
+            template <typename Type, typename... Args>
+            static MovableErasedType<Size, Align> erase_type(Args&&... args)
+            {
+                MovableErasedType<Size, Align> ret;
+                initialize_erased_<Type>(
+                    ret,
+                    erased_ops_no_copy_<Type>,
+                    std::forward<Args>(args)...
+                );
 
                 return ret;
+            }
+
+        protected:
+            using Operation = oki::intl_::helper_::AnyErasedOperations;
+
+            template <typename Type>
+            using is_small_buffered =
+                std::conditional_t<
+                    alignof(Type) <= Align && sizeof(Type) <= Size,
+                    std::true_type,
+                    std::false_type
+                >;
+
+            MovableErasedType() = default;
+
+            template <typename Type, typename Erased, typename Func, typename... Args>
+            static void initialize_erased_(Erased& erased, Func vtable, Args&&... args)
+            {
+                erased.template initalize_data_<Type>(std::forward<Args>(args)...);
+                erased.budgetVtable_ = vtable;
+            }
+
+            void copy_vtable_(const MovableErasedType<Size, Align>& that)
+            {
+                budgetVtable_ = that.budgetVtable_;
+            }
+
+            void vtable_dispatch_(MovableErasedType<Size, Align>* that, Operation op)
+            {
+                (*this->budgetVtable_)(*this, that, op);
+            }
+
+            template <typename Type, typename... Args>
+            void initalize_data_(Args&&... args)
+            {
+                if constexpr (is_small_buffered<Type>::value)
+                {
+                    new (storage_.buf_) Type{ std::forward<Args>(args)... };
+                }
+                else
+                {
+                    storage_.ptr_ = new Type{ std::forward<Args>(args)... };
+                }
+            }
+
+            template <typename Type>
+            void destroy_data_()
+            {
+                if constexpr (is_small_buffered<Type>::value)
+                {
+                    std::destroy_at(this->get_data_<Type>());
+                }
+                else
+                {
+                    delete this->get_data_<Type>();
+                }
             }
 
         private:
@@ -156,22 +193,12 @@ namespace oki
                 void* ptr_;
             } storage_;
 
-            using Operation = oki::intl_::helper_::AnyErasedOperations;
-
             // The name is a bit tongue-in-cheek but it gets the point across
             void (*budgetVtable_)(
-                ErasedType<Size, Align>&,
-                const ErasedType<Size, Align>*,
+                MovableErasedType<Size, Align>&,
+                MovableErasedType<Size, Align>*,
                 Operation
             );
-
-            template <typename Type>
-            using is_small_buffered =
-                std::conditional_t<
-                    alignof(Type) <= Align && sizeof(Type) <= Size,
-                    std::true_type,
-                    std::false_type
-                >;
 
             template <typename Type>
             const Type* get_data_() const
@@ -199,61 +226,161 @@ namespace oki
             }
 
             template <typename Type>
-            static void erased_ops_(
-                ErasedType<Size, Align>& self,
-                const ErasedType<Size, Align>* other,
+            static void erased_ops_no_copy_(
+                MovableErasedType<Size, Align>& self,
+                MovableErasedType<Size, Align>* other,
                 Operation op)
             {
-                if constexpr (is_small_buffered<Type>::value)
+                using ThisType = MovableErasedType<Size, Align>;
+
+                switch (op)
                 {
-                    switch (op)
-                    {
-                    case Operation::MOVE_CONSTR:
-                        new (self.storage_.buf_) Type{
-                            std::move(const_cast<Type&>(other->get_as<Type>()))
-                        };
-                        break;
-                    case Operation::MOVE_ASSIGN:
-                        self.move_from<Type>(
-                            std::move(*const_cast<ErasedType<Size, Align>*>(other))
-                        );
-                        break;
-                    case Operation::COPY_CONSTR:
-                        new (self.storage_.buf_) Type{
-                            other->get_as<Type>()
-                        };
-                        break;
-                    case Operation::COPY_ASSIGN:
-                        self.copy_from<Type>(*other);
-                        break;
-                    case Operation::DESTROY:
-                        std::destroy_at(self.get_data_<Type>());
-                        break;
-                    }
+                case Operation::MOVE_CONSTR:
+                    self.initalize_data_<Type>(
+                        std::move(other->get_as<Type>())
+                    );
+                    break;
+                case Operation::MOVE_ASSIGN:
+                    self.move_from<Type>(
+                        std::move(*other)
+                    );
+                    break;
+                case Operation::DESTROY:
+                    self.destroy_data_<Type>();
+                    break;
                 }
-                else
+            }
+        };
+
+        /*
+         * This is a class designed for a very specialized purpose: obscure
+         * the type of an object whose type is known by the caller.
+         * It is capable of small-buffer optimizing objects of a particular
+         * size and alignment (making it perhaps useful for a heterogeneous
+         * container of a template class with different instantiations?)
+         *
+         * Per the assumption that the caller *knows the type*, there is NO
+         * TYPE CHECKING for ANY operation. It is optimized for performance and
+         * is able to function without RTTI. Such is the benefit over std::any.
+         *
+         * This version stores copyable types.
+         */
+        template <std::size_t Size, std::size_t Align>
+        class ErasedType
+            : public MovableErasedType<Size, Align>
+        {
+        public:
+            ErasedType(const ErasedType<Size, Align>& that)
+            {
+                this->copy_vtable_(that);
+                this->vtable_dispatch_(
+                    // We can cast the constness away as long as
+                    // no data is written
+                    const_cast<ErasedType*>(&that),
+                    Operation::COPY_CONSTR
+                );
+            }
+
+            ErasedType(ErasedType<Size, Align>&& that)
+                : Base(std::move(that)) { }
+
+            /*
+             * As an example of the above, there is no guarantee that the other
+             * ErasedType<> holds a type that is equivalent to this one. It falls
+             * on the caller to be sure they're correct.
+             */
+            ErasedType<Size, Align>& operator=(const ErasedType<Size, Align>& that)
+            {
+                this->vtable_dispatch_(
+                    const_cast<ErasedType*>(&that),
+                    Operation::COPY_ASSIGN
+                );
+                return *this;
+            }
+
+            /*
+             * As an example of the above, there is no guarantee that the other
+             * ErasedType<> holds a type that is equivalent to this one. It falls
+             * on the caller to be sure they're correct.
+             */
+            ErasedType<Size, Align>& operator=(
+                ErasedType<Size, Align>&& that)
+            {
+                this->vtable_dispatch_(&that, Operation::MOVE_ASSIGN);
+                return *this;
+            }
+
+            /*
+             * Copy-assigns the value in the provided ErasedType<> to the
+             * one in this instance.
+             *
+             * Should be preferred over assignment.
+             */
+            template <typename Type>
+            void copy_from(const ErasedType<Size, Align>& that)
+            {
+                this->template hold<Type>(that.template get_as<Type>());
+            }
+
+            /*
+             * Creates an ErasedType<> instace holding a value of type Type,
+             * constructing one in-place by perfectly forwarding the variadic
+             * arguments.
+             */
+            template <typename Type, typename... Args>
+            static ErasedType<Size, Align> erase_type(Args&&... args)
+            {
+                ErasedType<Size, Align> ret;
+                Base::template initialize_erased_<Type>(
+                    ret,
+                    erased_ops_<Type>,
+                    std::forward<Args>(args)...
+                );
+
+                return ret;
+            }
+
+        private:
+            using Base = MovableErasedType<Size, Align>;
+
+            using Operation = typename Base::Operation;
+
+            template <typename Type>
+            static void erased_ops_(
+                Base& baseSelf,
+                Base* baseOther,
+                Operation op)
+            {
+                // Downcast to self
+                using ThisType = ErasedType<Size, Align>;
+                auto& self = static_cast<ThisType&>(baseSelf);
+                auto other = static_cast<ThisType*>(baseOther);
+
+                switch (op)
                 {
-                    switch (op)
-                    {
-                    case Operation::MOVE_CONSTR:
-                    case Operation::MOVE_ASSIGN:
-                        std::swap(
-                            self.storage_.ptr_,
-                            const_cast<ErasedType<Size, Align>*>(other)->storage_.ptr_
-                        );
-                        break;
-                    case Operation::COPY_CONSTR:
-                        self.storage_.ptr_ = new Type{
-                            other->get_as<Type>()
-                        };
-                        break;
-                    case Operation::COPY_ASSIGN:
-                        self.copy_from<Type>(*other);
-                        break;
-                    case Operation::DESTROY:
-                        delete self.get_data_<Type>();
-                        break;
-                    }
+                case Operation::MOVE_CONSTR:
+                    self.template initalize_data_<Type>(
+                        std::move(other->template get_as<Type>())
+                    );
+                    break;
+                case Operation::MOVE_ASSIGN:
+                    self.template move_from<Type>(
+                        std::move(*other)
+                    );
+                    break;
+                case Operation::COPY_CONSTR:
+                    self.template initalize_data_<Type>(
+                        std::as_const(*other).template get_as<Type>()
+                    );
+                    break;
+                case Operation::COPY_ASSIGN:
+                    self.template copy_from<Type>(
+                        std::as_const(*other)
+                    );
+                    break;
+                case Operation::DESTROY:
+                    self.template destroy_data_<Type>();
+                    break;
                 }
             }
 
@@ -261,7 +388,11 @@ namespace oki
         };
 
         template <typename Type>
-        using OptimalErasedType = ErasedType<sizeof(Type), alignof(Type)>;
+        using OptimalErasedType = std::conditional_t<
+            std::is_copy_assignable_v<Type> && std::is_copy_constructible_v<Type>,
+            oki::intl_::ErasedType<sizeof(Type), alignof(Type)>,
+            oki::intl_::MovableErasedType<sizeof(Type), alignof(Type)>
+        >;
 
         /*
          * An opaque class representing a type index for an associative map.


### PR DESCRIPTION
- Refactored `ErasedType`:
  - Broke it into two classes, one for move-only and one for copyable
  - Factored out smaller behaviors to improve extensibility and readability
  - Added tests for construction + move-only types
  - Updated `OptimalErasedType` to choose between move-only and copyable