### PR TITLE
Add include guards to headers missing them

### DIFF
--- a/src/oki/oki_component.h
+++ b/src/oki/oki_component.h
@@ -1,3 +1,6 @@
+#ifndef OKI_COMPONENT_H
+#define OKI_COMPONENT_H
+
 #include "oki/oki_handle.h"
 #include "oki/util/oki_container.h"
 #include "oki/util/oki_handle_gen.h"
@@ -503,3 +506,5 @@ namespace oki
         }
     };
 }
+
+#endif // OKI_COMPONENT_H

--- a/src/oki/util/oki_type_erasure.h
+++ b/src/oki/util/oki_type_erasure.h
@@ -1,3 +1,6 @@
+#ifndef OKI_TYPE_ERASURE_H
+#define OKI_TYPE_ERASURE_H
+
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -454,3 +457,5 @@ namespace std
         }
     };
 }
+
+#endif // OKI_TYPE_ERASURE_H


### PR DESCRIPTION
Added include guards to `oki_component.h` and `oki_type_erasure.h`, which I had embarrassingly left out. Oops.

I will be adding linting to this project soon to prevent this type of error in the future.