### PR TITLE
Add basic systems and system manager class

### DIFF
--- a/src/oki/oki_system.h
+++ b/src/oki/oki_system.h
@@ -1,0 +1,301 @@
+#ifndef OKI_SYSTEM_H
+#define OKI_SYSTEM_H
+
+#include "oki/util/oki_handle_gen.h"
+#include "oki/util/oki_type_erasure.h"
+#include "oki/oki_handle.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace oki
+{
+    using SystemPriority = std::uint16_t;
+
+    class SystemOptions;
+    class SystemManager;
+
+    class System
+    {
+    public:
+        virtual ~System() = default;
+
+        virtual void step(oki::SystemManager&, oki::SystemOptions&) = 0;
+    };
+
+    /*
+     * Heap-allocates a functional system given a provided step() function.
+     *
+     * The caller is still responsible for owning this object (although it
+     * can be leaked if it will last the entire lifetime of the program).
+     */
+    template <typename StepFunction>
+    std::unique_ptr<System> create_functional_system(StepFunction&& callback)
+    {
+        class FunctionalSystem : public oki::System
+        {
+        public:
+            FunctionalSystem(StepFunction callback)
+                : callback_(callback) { }
+
+            void step(oki::SystemManager& man, oki::SystemOptions& opts)
+                override
+            {
+                callback_(man, opts);
+            }
+
+        private:
+            StepFunction callback_;
+        };
+
+        return std::unique_ptr<oki::System>(
+            new FunctionalSystem{ std::forward<StepFunction>(callback) }
+        );
+    }
+
+    class SystemOptions
+    {
+    public:
+        bool will_skip() const noexcept
+        {
+            return loopChoice_ == SKIP;
+        }
+
+        void skip_rest() noexcept
+        {
+            loopChoice_ = SKIP;
+        }
+
+        std::pair<bool, int> exit_info() const noexcept
+        {
+            return { loopChoice_ == EXIT, exitCode_ };
+        }
+
+        void exit(int code = 0) noexcept
+        {
+            exitCode_ = code;
+            loopChoice_ = EXIT;
+        }
+
+        bool will_remove() const noexcept
+        {
+            return shouldRemove_;
+        }
+
+        void remove_me() noexcept
+        {
+            shouldRemove_ = true;
+        }
+
+    private:
+
+        int exitCode_;
+
+        enum
+        {
+            EXIT,
+            SKIP,
+            CONT
+        } loopChoice_;
+
+        bool shouldRemove_;
+
+        SystemOptions()
+            : exitCode_(0), loopChoice_(CONT), shouldRemove_(false) { }
+
+        friend class SystemManager;
+    };
+
+    class SystemManager
+    {
+    public:
+        SystemManager() noexcept = default;
+        SystemManager(const SystemManager&) = delete;
+        SystemManager(SystemManager&&) = default;
+        ~SystemManager() = default;
+
+        SystemManager& operator=(const SystemManager&) = delete;
+        SystemManager& operator=(SystemManager&&) = default;
+
+        /*
+         * Adds a system to be run by the SystemManager with a given priority.
+         *
+         * Every time the SystemManager calls step(), systems with higher
+         * priority will run before those with lower priority. For matching
+         * values, a system that was added later will run last.
+         *
+         * Systems CAN be added during a step() or run(), and whether they will
+         * be called "this" frame is dependent on their priority.
+         *
+         * The SystemManager DOES NOT own systems. References to added systems
+         * must remain valid for their entire tenure with the SystemManager.
+         *
+         * Returns a handle which can be used to refer to this system for
+         * deletion/access/etc.
+         */
+        template <typename SystemType>
+        oki::Handle add_priority_system(
+            oki::SystemPriority priority,
+            SystemType& system
+        )
+        {
+            static_assert(std::is_base_of_v<oki::System, SystemType>);
+
+            SystemData sysData;
+            sysData.system_ = std::addressof(system);
+            sysData.handle_ = handleGen_.create_handle();
+            sysData.priority_ = priority;
+
+            // We want to insert this system after higher-priority sytems
+            // and, if they match priorities, after its peers
+            auto sysIter = std::find_if(systems_.begin(), systems_.end(),
+            [=](const auto& elem) {
+                return elem.priority_ < priority;
+            });
+
+            systems_.insert(sysIter, sysData);
+            return sysData.handle_;
+        }
+
+        /*
+         * Adds a new system with priority 0.
+         */
+        template <typename SystemType>
+        oki::Handle add_system(SystemType& system)
+        {
+            return this->add_priority_system<SystemType>(
+                0, system
+            );
+        }
+
+        /*
+         * Removes a system given its handle.
+         *
+         * This CAN occur during a run() a step().
+         */
+        bool remove_system(oki::Handle handle)
+        {
+            auto sysIter = this->seek_handle_(handle);
+
+            if (sysIter != systems_.end())
+            {
+                // Does not hard erase (could be occuring during iteration)
+                sysIter->handle_ = oki::intl_::get_invalid_handle_constant();
+                sysIter->system_ = nullptr;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /*
+         * Returns a pointer to the system referred to by provided handle.
+         *
+         * The SystemManager is not designed for this and it is not
+         * recommended to call this often.
+         */
+        oki::System* get_system(oki::Handle handle)
+        {
+            auto sysIter = this->seek_handle_(handle);
+            return (sysIter != systems_.end()) ? sysIter->system_ : nullptr;
+        }
+
+        /*
+         * Runs a single step, calling the step() function of each associated
+         * system exactly once. Respects priority.
+         *
+         * Returns two values indicating whether one of the systems has
+         * requested to exit and with which code.
+         */
+        std::pair<bool, int> step()
+        {
+            for (auto sysIter = systems_.begin(); sysIter != systems_.end();)
+            {
+                // If this system was removed in the last pass,
+                // hard erase it
+                if (!sysIter->system_)
+                {
+                    sysIter = systems_.erase(sysIter);
+                    continue;
+                }
+
+                oki::SystemOptions options;
+                sysIter->system_->step(*this, options);
+
+                if (options.will_remove())
+                {
+                    sysIter = systems_.erase(sysIter);
+                    continue;
+                }
+
+                if (options.will_skip())
+                {
+                    break;
+                }
+
+                auto exitPair = options.exit_info();
+                if (exitPair.first)
+                {
+                    return exitPair;
+                }
+
+                ++sysIter;
+            }
+
+            return { false, 0 };
+        }
+
+        /*
+         * Calls step() repeatedly until all systems have been removed or
+         * one of the systems has requested to exit.
+         */
+        int run()
+        {
+            // If all systems have been removed, exit
+            while (!systems_.empty())
+            {
+                auto [exit, code] = this->step();
+
+                if (exit)
+                {
+                    return code;
+                }
+            }
+
+            return 0;
+        }
+
+    private:
+        struct SystemData
+        {
+            oki::System* system_;
+            oki::Handle handle_;
+            oki::SystemPriority priority_;
+        };
+
+        // This choice of data structure makes the implementation easier and
+        // its cache misses should be acceptable because the virtual function
+        // associated with an oki::System will miss anyway (+ quantity is low)
+        std::list<SystemData> systems_;
+
+        oki::intl_::DefaultHandleGenerator<oki::Handle> handleGen_;
+
+        auto seek_handle_(oki::Handle handle) noexcept
+            -> typename decltype(systems_)::iterator
+        {
+            // A linear search is fine, because in general there should
+            // be very few systems
+            return std::find_if(systems_.begin(), systems_.end(),
+            [=](const auto& elem) {
+                return elem.handle_ == handle;
+            });
+        }
+    };
+}
+
+#endif // OKI_SYSTEM_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(oki_unit
     oki_test_type_erasure.cpp
     oki_test_component.cpp
     oki_test_observer.cpp
+    oki_test_system.cpp
 )
 target_include_directories(oki_unit PRIVATE "../src/")
 target_link_libraries(oki_unit PRIVATE Catch2::Catch2WithMain)

--- a/test/oki_test_system.cpp
+++ b/test/oki_test_system.cpp
@@ -1,0 +1,160 @@
+#include "oki/oki_handle.h"
+#include "oki/oki_system.h"
+
+#include "catch2/catch_test_macros.hpp"
+
+#include <vector>
+
+struct TestSystem
+    : public oki::System
+{
+    void step(oki::SystemManager& manager, oki::SystemOptions& opts) override
+    {
+        ++numCalls;
+    }
+
+    unsigned int numCalls = 0;
+};
+
+TEST_CASE("SystemManager")
+{
+    oki::SystemManager sysMan;
+    TestSystem system;
+
+    auto handle = sysMan.add_priority_system(10, system);
+
+    SECTION("can add a system")
+    {
+        REQUIRE_FALSE(oki::intl_::is_bad_handle(handle));
+    }
+    SECTION("can call a system's step()")
+    {
+        auto [exit, _] = sysMan.step();
+
+        REQUIRE_FALSE(exit);
+        REQUIRE(system.numCalls == 1);
+    }
+    SECTION("can add a functional system")
+    {
+        bool called = false;
+        auto funcSys = oki::create_functional_system([&](auto&...) {
+            called = true;
+        });
+
+        sysMan.add_system(*funcSys);
+        sysMan.step();
+
+        REQUIRE(called);
+    }
+    SECTION("runs systems in priority-order")
+    {
+        std::vector<int> callOrder;
+        auto titled_func_sys = [&callOrder](int title) {
+            return oki::create_functional_system([=, &callOrder](auto&...) {
+                callOrder.push_back(title);
+            });
+        };
+
+        std::unique_ptr<oki::System> systems[] = {
+            titled_func_sys(0),
+            titled_func_sys(1),
+            titled_func_sys(2),
+            titled_func_sys(3),
+            titled_func_sys(4),
+            titled_func_sys(5),
+            titled_func_sys(6),
+        };
+
+        sysMan.add_priority_system(10, *systems[0]);
+        sysMan.add_priority_system(5,  *systems[1]);
+        sysMan.add_priority_system(15, *systems[2]);
+        sysMan.add_priority_system(10, *systems[3]);
+        sysMan.add_priority_system(10, *systems[4]);
+        sysMan.add_priority_system(1,  *systems[5]);
+        sysMan.add_priority_system(20, *systems[6]);
+
+        sysMan.step();
+        REQUIRE(callOrder == std::vector<int>{ 6, 2, 0, 3, 4, 1, 5 });
+    }
+    SECTION("can remove a system")
+    {
+        sysMan.step();
+        REQUIRE(system.numCalls == 1);
+
+        REQUIRE(sysMan.remove_system(handle));
+
+        sysMan.step();
+        REQUIRE(system.numCalls == 1);
+
+        CHECK_FALSE(sysMan.remove_system(handle));
+    }
+    SECTION("halts when there are no systems")
+    {
+        REQUIRE(sysMan.remove_system(handle));
+
+        // TODO: Find a timeout option for Catch2
+        // (if this fails, we just stall indefinitely)
+        sysMan.run();
+        REQUIRE(true);
+    }
+    SECTION("can remove systems while running")
+    {
+        unsigned int numCalls = 0;
+        auto funcSys = oki::create_functional_system(
+        [&](oki::SystemManager& manager, oki::SystemOptions& opts) {
+            ++numCalls;
+            opts.remove_me();
+            manager.remove_system(handle);
+        });
+
+        sysMan.add_priority_system(20, *funcSys);
+        sysMan.run();
+
+        REQUIRE(numCalls == 1);
+        REQUIRE(system.numCalls == 0);
+    }
+    SECTION("can exit from run()")
+    {
+        auto funcSys = oki::create_functional_system(
+        [](auto&, oki::SystemOptions& opts) {
+            opts.exit(1);
+        });
+
+        sysMan.add_priority_system(20, *funcSys);
+
+        REQUIRE(sysMan.run() == 1);
+        CHECK(system.numCalls == 0);
+    }
+    SECTION("can skip other systems")
+    {
+        unsigned int counter = 0;
+
+        auto funcSys = oki::create_functional_system(
+        [&](auto&, oki::SystemOptions& opts) {
+            if (counter == 5)
+            {
+                opts.exit();
+                return;
+            }
+
+            ++counter;
+            opts.skip_rest();
+        });
+
+        sysMan.add_priority_system(20, *funcSys);
+
+        sysMan.run();
+
+        CHECK(system.numCalls == 0);
+        CHECK(counter == 5);
+    }
+    SECTION("can get inserted systems")
+    {
+        CHECK(&system == sysMan.get_system(handle));
+    }
+    SECTION("cannot get nonexistent systems")
+    {
+        sysMan.remove_system(handle);
+        CHECK_FALSE(sysMan.get_system(handle));
+    }
+}


### PR DESCRIPTION
Added new oki::System and oki::SystemManager as a very simple default implementation of systems (the S in ECS).

Note that it is not highly optimized. In fact, it's rather slow. That said, other parts of the library do not rely on this feature and end users are free to switch it out as wanted.