### PR TITLE
Include systems, utility classes in oki_ecs header

### DIFF
--- a/src/oki/oki_ecs.h
+++ b/src/oki/oki_ecs.h
@@ -3,5 +3,46 @@
 
 #include "oki/oki_component.h"
 #include "oki/oki_observer.h"
+#include "oki/oki_system.h"
+
+#include <type_traits>
+
+namespace oki
+{
+    class Engine
+        : public oki::ComponentManager
+        , public oki::SignalManager
+        , public oki::SystemManager { };
+
+    template <typename ChildClass = void>
+    class EngineSystem
+        : public oki::System
+    {
+    public:
+        virtual ~EngineSystem() = default;
+
+        virtual void step(oki::Engine&, oki::SystemOptions&) = 0;
+
+    private:
+        void step(oki::SystemManager& manager, oki::SystemOptions& opts)
+            override
+        {
+            // Optional CRTP
+            if constexpr (std::is_base_of_v<EngineSystem, ChildClass>)
+            {
+                static_cast<ChildClass*>(this)->step(
+                    static_cast<oki::Engine&>(manager),
+                    opts
+                );
+            }
+            else
+            {
+                this->step(static_cast<oki::Engine&>(manager), opts);
+            }
+        }
+    };
+
+    using SimpleEngineSystem = oki::EngineSystem<>;
+}
 
 #endif // OKI_ECS_H


### PR DESCRIPTION
Modified oki_ecs.h to include oki_system.h (an accidental exclusion from before). Created utility classes to reduce boilerplate and streamline the ECS architecture for the end user.