### PR TITLE
Update project to use modern CMake utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(oki LANGUAGES CXX)
+
+# Only if we're the top-level project should the tests get built
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    include(CTest)
+    add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ At the moment, this "library" is header-only (due in large part to the heavy use
 So, building is easy: `#include "oki/oki_ecs.h"`, use the library, then compile your code.
 
 There are a set of tests using `catch2`, which `CMake` will download and install automatically. So, the steps are similarly simple:
-- `cd test`
-- `cmake .`
+- `cmake -S . -B build`
+- `cd build`
 - `cmake --build .`
-- `./oki_unit`
+- `ctest`

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,24 +1,33 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.19)
 include(FetchContent)
 
-project(oki_unit LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 17)
-
+# Fetch and set up Catch2 dependency
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG        v3.0.1
 )
-
 FetchContent_MakeAvailable(Catch2)
 
+# Express source files for unit testing [target: oki_unit]
 add_executable(oki_unit
-    oki_test_handle.cpp
-    oki_test_container.cpp
-    oki_test_type_erasure.cpp
     oki_test_component.cpp
+    oki_test_container.cpp
+    oki_test_handle.cpp
     oki_test_observer.cpp
     oki_test_system.cpp
+    oki_test_type_erasure.cpp
 )
-target_include_directories(oki_unit PRIVATE "../src/")
+
+# Express external dependencies
+target_include_directories(oki_unit PRIVATE "../src")
 target_link_libraries(oki_unit PRIVATE Catch2::Catch2WithMain)
+
+# Describe compiler features
+target_compile_features(oki_unit PUBLIC cxx_std_17)
+set_target_properties(oki_unit PROPERTIES CXX_EXTENSIONS OFF)
+
+# Finally, register the unit tests
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+include(Catch)
+catch_discover_tests(oki_unit)


### PR DESCRIPTION
A number of cleanliness and maintainability changes have been made:
 - Incorrect CMake version was listed, changed to higher version
 - Use Catch2 test discovery with CMake for automated tests with `ctest`
 - Use more modern CMake approaches (I have some knowledge gaps so this is WIP)
 - Add top-level CMakeLists.txt
 - Update README instructions for out-of-source build