### PR TITLE
Refactor type erasure

### DIFF
--- a/src/oki/oki_component.h
+++ b/src/oki/oki_component.h
@@ -383,8 +383,8 @@ private:
     template <typename Type>
     Container<Type>& create_cont_()
     {
-        auto [iter, _] = data_.emplace(oki::intl_::get_type<Type>(),
-            ErasedContainer::erase_type<Container<Type>>());
+        auto [iter, _]
+            = data_.emplace(oki::intl_::get_type<Type>(), Container<Type>());
 
         return iter->second;
     }
@@ -392,11 +392,13 @@ private:
     template <typename Type>
     Container<Type>& get_or_create_cont_()
     {
-        auto iter = data_.find(oki::intl_::get_type<Type>());
+        auto type = oki::intl_::get_type<Type>();
+        auto iter = data_.find(type);
 
         if (iter == data_.end()) {
-            iter = data_.emplace_hint(iter, oki::intl_::get_type<Type>(),
-                ErasedContainer::erase_type<Container<Type>>());
+            // This branch is relatively unlikely, so we can avoid
+            // type-erasing a new Container<Type> most of the time
+            iter = data_.emplace(type, Container<Type>()).first;
         }
 
         return iter->second.template get_as<Container<Type>>();

--- a/src/oki/oki_observer.h
+++ b/src/oki/oki_observer.h
@@ -265,7 +265,7 @@ private:
     template <typename Subject>
     static ErasedPipeData create_erased_pipe_()
     {
-        return ErasedPipeData { ErasedPipe::erase_type<Pipe<Subject>>(),
+        return ErasedPipeData { Pipe<Subject> {},
             &disconn_type_erased_<Subject> };
     }
 };

--- a/src/oki/util/oki_type_erasure.h
+++ b/src/oki/util/oki_type_erasure.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
 #include <typeindex>
 #include <typeinfo>
@@ -12,65 +13,140 @@
 
 namespace oki {
 namespace intl_ {
-namespace helper_ {
-enum class AnyErasedOperations
-{
-    COPY_CONSTR,
-    COPY_ASSIGN,
-    MOVE_CONSTR,
-    MOVE_ASSIGN,
-    DESTROY
-};
-}
-
-/*
- * This is a class designed for a very specialized purpose: obscure
- * the type of an object whose type is known by the caller.
- * It is capable of small-buffer optimizing objects of a particular
- * size and alignment (making it perhaps useful for a heterogeneous
- * container of a template class with different instantiations?)
- *
- * Per the assumption that the caller *knows the type*, there is NO
- * TYPE CHECKING for ANY operation. It is optimized for performance and
- * is able to function without RTTI. Such is the benefit over std::any.
- *
- * This version in particular stores move-only types.
- */
 template <std::size_t Size, std::size_t Align>
-class MovableErasedType
+class SmallBufStorage
 {
 public:
-    MovableErasedType(MovableErasedType<Size, Align>&& that)
-        : budgetVtable_(that.budgetVtable_)
+    template <typename Type>
+    const Type* get_ptr() const
     {
-        this->vtable_dispatch_(&that, Operation::MOVE_CONSTR);
+        return std::launder(reinterpret_cast<const Type*>(&buf_));
     }
 
-    ~MovableErasedType()
+    template <typename Type>
+    Type* get_ptr()
     {
-        this->vtable_dispatch_(nullptr, Operation::DESTROY);
+        return const_cast<Type*>(std::as_const(*this).template get_ptr<Type>());
     }
 
-    /*
-     * As an example of the above, there is no guarantee that the other
-     * MovableErasedType<> holds a type that is equivalent to this one.
-     * It falls on the caller to be sure they're correct.
-     */
-    MovableErasedType<Size, Align>& operator=(
-        MovableErasedType<Size, Align>&& that)
+    template <typename Type, typename... Args>
+    void init(Args&&... args)
     {
-        this->vtable_dispatch_(&that, Operation::MOVE_ASSIGN);
+        new (buf_) Type(std::forward<Args>(args)...);
+    }
+
+    template <typename Type>
+    void destroy()
+    {
+        std::destroy_at(this->get_ptr<Type>());
+    }
+
+private:
+    alignas(Align) std::byte buf_[Size];
+};
+
+class HeapStorage
+{
+public:
+    template <typename Type>
+    const Type* get_ptr() const
+    {
+        return static_cast<const Type*>(ptr_);
+    }
+
+    template <typename Type>
+    Type* get_ptr()
+    {
+        return const_cast<Type*>(std::as_const(*this).template get_ptr<Type>());
+    }
+
+    template <typename Type, typename... Args>
+    void init(Args&&... args)
+    {
+        ptr_ = new Type(std::forward<Args>(args)...);
+    }
+
+    template <typename Type>
+    void destroy()
+    {
+        delete this->get_ptr<Type>();
+    }
+
+private:
+    void* ptr_;
+};
+
+template <std::size_t Size, std::size_t Align>
+class ErasedType
+{
+public:
+    ErasedType() = default;
+
+    ErasedType(const ErasedType<Size, Align>& that)
+        : ErasedType()
+    {
+        this->copy_from(that);
+    }
+
+    ErasedType(ErasedType<Size, Align>&& that)
+        : ErasedType()
+    {
+        this->move_from(std::move(that));
+    }
+
+    template <typename Type,
+        std::enable_if_t<std::negation_v<std::is_same<std::decay_t<Type>,
+                             ErasedType<Size, Align>>>,
+            int>
+        = 0>
+    ErasedType(Type&& value)
+        : ErasedType()
+    {
+        using InnerType = std::decay_t<Type>;
+        this->emplace<InnerType>(std::forward<Type>(value));
+    }
+
+    ~ErasedType() { this->reset(); }
+
+    ErasedType<Size, Align>& operator=(ErasedType<Size, Align> that)
+    {
+        this->move_from(std::move(that));
         return *this;
     }
 
-    /*
-     * Returns a reference to the stored value, assuming (and not
-     * checking whether) the caller is correct about the type.
-     */
+    template <typename Type, typename... Args>
+    void emplace(Args&&... args)
+    {
+        this->reset();
+        this->reinit_<Type>(std::forward<Args>(args)...);
+    }
+
+    void copy_from(const ErasedType<Size, Align>& that)
+    {
+        if (that.copy_) {
+            (this->*that.copy_)(that);
+        }
+    }
+
+    void move_from(ErasedType<Size, Align>&& that)
+    {
+        if (that.move_) {
+            (this->*that.move_)(std::move(that));
+        }
+    }
+
     template <typename Type>
     const Type& get_as() const
     {
-        return *this->get_data_<Type>();
+        if (!destroy_) {
+            throw std::runtime_error("get_as() called on empty ErasedType");
+        }
+
+        if constexpr (is_sbo_<Type>()) {
+            return *storage_.buf_.template get_ptr<Type>();
+        } else {
+            return *storage_.ptr_.template get_ptr<Type>();
+        }
     }
 
     template <typename Type>
@@ -79,267 +155,107 @@ public:
         return const_cast<Type&>(std::as_const(*this).template get_as<Type>());
     }
 
-    /*
-     * Takes a value matching the underlying type and assigns
-     * it to the internal object with perfect forwarding.
-     *
-     * This should be preferred over assigning the MovableErasedType<>.
-     */
-    template <typename Type, typename InsertType>
-    void hold(InsertType&& value)
+    void reset()
     {
-        this->get_as<Type>() = std::forward<InsertType>(value);
-    }
-
-    /*
-     * Move-assigns the value in the provided MovableErasedType<> to
-     * the one in this instance.
-     *
-     * Should be preferred over assignment.
-     */
-    template <typename Type>
-    void move_from(MovableErasedType<Size, Align>&& that)
-    {
-        if constexpr (is_small_buffered<Type>::value) {
-            this->hold<Type>(std::move(that.get_as<Type>()));
-        } else {
-            std::swap(storage_.ptr_, that.storage_.ptr_);
-        }
-    }
-
-    /*
-     * Creates a MovableErasedType<> instace holding a value of type
-     * Type, constructing one in-place by perfectly forwarding the
-     * variadic arguments.
-     */
-    template <typename Type, typename... Args>
-    static MovableErasedType<Size, Align> erase_type(Args&&... args)
-    {
-        MovableErasedType<Size, Align> ret;
-        initialize_erased_<Type>(
-            ret, erased_ops_no_copy_<Type>, std::forward<Args>(args)...);
-
-        return ret;
-    }
-
-protected:
-    using Operation = oki::intl_::helper_::AnyErasedOperations;
-
-    template <typename Type>
-    using is_small_buffered
-        = std::conditional_t<alignof(Type) <= Align && sizeof(Type) <= Size,
-            std::true_type, std::false_type>;
-
-    MovableErasedType() = default;
-
-    template <typename Type, typename Erased, typename Func, typename... Args>
-    static void initialize_erased_(Erased& erased, Func vtable, Args&&... args)
-    {
-        erased.template initalize_data_<Type>(std::forward<Args>(args)...);
-        erased.budgetVtable_ = vtable;
-    }
-
-    void copy_vtable_(const MovableErasedType<Size, Align>& that)
-    {
-        budgetVtable_ = that.budgetVtable_;
-    }
-
-    void vtable_dispatch_(MovableErasedType<Size, Align>* that, Operation op)
-    {
-        (*this->budgetVtable_)(*this, that, op);
-    }
-
-    template <typename Type, typename... Args>
-    void initalize_data_(Args&&... args)
-    {
-        if constexpr (is_small_buffered<Type>::value) {
-            new (storage_.buf_) Type { std::forward<Args>(args)... };
-        } else {
-            storage_.ptr_ = new Type { std::forward<Args>(args)... };
-        }
-    }
-
-    template <typename Type>
-    void destroy_data_()
-    {
-        if constexpr (is_small_buffered<Type>::value) {
-            std::destroy_at(this->get_data_<Type>());
-        } else {
-            delete this->get_data_<Type>();
+        if (destroy_) {
+            (this->*destroy_)();
+            destroy_ = nullptr;
+            copy_ = nullptr;
+            move_ = nullptr;
         }
     }
 
 private:
-    union Storage
+    // Storage data
+    using BufferStorage = SmallBufStorage<Size, Align>;
+
+    static_assert(std::is_trivial_v<BufferStorage>);
+    static_assert(std::is_trivial_v<HeapStorage>);
+
+    union
     {
-        alignas(Align) std::byte buf_[Size];
-        void* ptr_;
+        BufferStorage buf_;
+        HeapStorage ptr_;
     } storage_;
 
-    // The name is a bit tongue-in-cheek but it gets the point across
-    void (*budgetVtable_)(MovableErasedType<Size, Align>&,
-        MovableErasedType<Size, Align>*, Operation);
-
     template <typename Type>
-    const Type* get_data_() const
+    constexpr static bool is_sbo_()
     {
-        if constexpr (is_small_buffered<Type>::value) {
-            return std::launder(reinterpret_cast<const Type*>(&storage_.buf_));
+        return sizeof(Type) <= Size && alignof(Type) <= Align;
+    }
+
+    template <typename Type, typename Function>
+    void visit_storage_(Function func)
+    {
+        if constexpr (is_sbo_<Type>()) {
+            func(storage_.buf_);
         } else {
-            return static_cast<const Type*>(storage_.ptr_);
+            func(storage_.ptr_);
+        }
+    }
+
+    // Type-erased destruction
+    using DestroyFunc = void (ErasedType::*)();
+    DestroyFunc destroy_ = nullptr;
+
+    template <typename Type>
+    void destroy_inner_()
+    {
+        this->visit_storage_<Type>(
+            [](auto& data) { data.template destroy<Type>(); });
+    }
+
+    // Type-erased construction
+    using CopyConstruct = void (ErasedType::*)(const ErasedType&);
+    CopyConstruct copy_ = nullptr;
+
+    using MoveConstruct = void (ErasedType::*)(ErasedType&&);
+    MoveConstruct move_ = nullptr;
+
+    template <typename Type>
+    void copy_inner_(const ErasedType& that)
+    {
+        if constexpr (std::is_copy_constructible_v<Type>) {
+            this->reinit_<Type>(that.get_as<Type>());
+        } else {
+            throw std::logic_error(
+                "Only use copy_from() on copy-constructible types");
         }
     }
 
     template <typename Type>
-    Type* get_data_()
+    void move_inner_(ErasedType&& that)
     {
-        return const_cast<Type*>(
-            std::as_const(*this).template get_data_<Type>());
-    }
-
-    template <typename Type>
-    static void erased_ops_no_copy_(MovableErasedType<Size, Align>& self,
-        MovableErasedType<Size, Align>* other, Operation op)
-    {
-        using ThisType = MovableErasedType<Size, Align>;
-
-        switch (op) {
-        case Operation::MOVE_CONSTR:
-            self.initalize_data_<Type>(std::move(other->get_as<Type>()));
-            break;
-        case Operation::MOVE_ASSIGN:
-            self.move_from<Type>(std::move(*other));
-            break;
-        case Operation::DESTROY:
-            self.destroy_data_<Type>();
-            break;
+        if constexpr (std::is_move_constructible_v<Type>) {
+            this->reinit_<Type>(std::move(that.get_as<Type>()));
+        } else {
+            throw std::logic_error(
+                "Only use move_from() on move-constructible types");
         }
     }
-};
 
-/*
- * This is a class designed for a very specialized purpose: obscure
- * the type of an object whose type is known by the caller.
- * It is capable of small-buffer optimizing objects of a particular
- * size and alignment (making it perhaps useful for a heterogeneous
- * container of a template class with different instantiations?)
- *
- * Per the assumption that the caller *knows the type*, there is NO
- * TYPE CHECKING for ANY operation. It is optimized for performance and
- * is able to function without RTTI. Such is the benefit over std::any.
- *
- * This version stores copyable types.
- */
-template <std::size_t Size, std::size_t Align>
-class ErasedType : public MovableErasedType<Size, Align>
-{
-public:
-    ErasedType(const ErasedType<Size, Align>& that)
-    {
-        this->copy_vtable_(that);
-        this->vtable_dispatch_(
-            // We can cast the constness away as long as
-            // no data is written
-            const_cast<ErasedType*>(&that), Operation::COPY_CONSTR);
-    }
-
-    ErasedType(ErasedType<Size, Align>&& that)
-        : Base(std::move(that))
-    {
-    }
-
-    /*
-     * As an example of the above, there is no guarantee that the other
-     * ErasedType<> holds a type that is equivalent to this one. It falls
-     * on the caller to be sure they're correct.
-     */
-    ErasedType<Size, Align>& operator=(const ErasedType<Size, Align>& that)
-    {
-        this->vtable_dispatch_(
-            const_cast<ErasedType*>(&that), Operation::COPY_ASSIGN);
-        return *this;
-    }
-
-    /*
-     * As an example of the above, there is no guarantee that the other
-     * ErasedType<> holds a type that is equivalent to this one. It falls
-     * on the caller to be sure they're correct.
-     */
-    ErasedType<Size, Align>& operator=(ErasedType<Size, Align>&& that)
-    {
-        this->vtable_dispatch_(&that, Operation::MOVE_ASSIGN);
-        return *this;
-    }
-
-    /*
-     * Copy-assigns the value in the provided ErasedType<> to the
-     * one in this instance.
-     *
-     * Should be preferred over assignment.
-     */
-    template <typename Type>
-    void copy_from(const ErasedType<Size, Align>& that)
-    {
-        this->template hold<Type>(that.template get_as<Type>());
-    }
-
-    /*
-     * Creates an ErasedType<> instace holding a value of type Type,
-     * constructing one in-place by perfectly forwarding the variadic
-     * arguments.
-     */
+    // Initialization
     template <typename Type, typename... Args>
-    static ErasedType<Size, Align> erase_type(Args&&... args)
+    void reinit_(Args&&... args)
     {
-        ErasedType<Size, Align> ret;
-        Base::template initialize_erased_<Type>(
-            ret, erased_ops_<Type>, std::forward<Args>(args)...);
+        static_assert(std::is_constructible_v<Type, Args...>);
 
-        return ret;
+        // First, destroy whatever we're holding
+        this->reset();
+
+        // Then, load the new values
+        this->visit_storage_<Type>([&](auto& data) {
+            data.template init<Type>(std::forward<Args>(args)...);
+        });
+
+        destroy_ = &ErasedType<Size, Align>::destroy_inner_<Type>;
+        copy_ = &ErasedType<Size, Align>::copy_inner_<Type>;
+        move_ = &ErasedType<Size, Align>::move_inner_<Type>;
     }
-
-private:
-    using Base = MovableErasedType<Size, Align>;
-
-    using Operation = typename Base::Operation;
-
-    template <typename Type>
-    static void erased_ops_(Base& baseSelf, Base* baseOther, Operation op)
-    {
-        // Downcast to self
-        using ThisType = ErasedType<Size, Align>;
-        auto& self = static_cast<ThisType&>(baseSelf);
-        auto other = static_cast<ThisType*>(baseOther);
-
-        switch (op) {
-        case Operation::MOVE_CONSTR:
-            self.template initalize_data_<Type>(
-                std::move(other->template get_as<Type>()));
-            break;
-        case Operation::MOVE_ASSIGN:
-            self.template move_from<Type>(std::move(*other));
-            break;
-        case Operation::COPY_CONSTR:
-            self.template initalize_data_<Type>(
-                std::as_const(*other).template get_as<Type>());
-            break;
-        case Operation::COPY_ASSIGN:
-            self.template copy_from<Type>(std::as_const(*other));
-            break;
-        case Operation::DESTROY:
-            self.template destroy_data_<Type>();
-            break;
-        }
-    }
-
-    ErasedType() = default;
 };
 
 template <typename Type>
-using OptimalErasedType = std::conditional_t<std::is_copy_assignable_v<Type>
-        && std::is_copy_constructible_v<Type>,
-    oki::intl_::ErasedType<sizeof(Type), alignof(Type)>,
-    oki::intl_::MovableErasedType<sizeof(Type), alignof(Type)>>;
+using OptimalErasedType = oki::intl_::ErasedType<sizeof(Type), alignof(Type)>;
 
 /*
  * An opaque class representing a type index for an associative map.

--- a/test/oki_test_util.h
+++ b/test/oki_test_util.h
@@ -61,7 +61,7 @@ struct ObjHelper
     static void test(std::optional<std::size_t> constr,
         std::optional<std::size_t> copies, std::optional<std::size_t> moves)
     {
-        test_helper::ObjHelper::test();
+        test();
 
         if (constr) {
             CHECK(numConstructs == constr.value());
@@ -72,6 +72,12 @@ struct ObjHelper
         if (moves) {
             CHECK(numMoves == moves.value());
         }
+    }
+
+    static void test_max_num_copies(std::size_t copies)
+    {
+        test();
+        CHECK(numCopies <= copies);
     }
 
     std::size_t value_;


### PR DESCRIPTION
Refactor ErasedType to improve readability and maintainability:
- Encapsulate storage types (small-buffer and `void*``) into their own classes to improve readability (it is much easier to prove the type erasure is compliant this way)
- Change interface to more closely match std::any
- Allow non-matching type assignment (this is a slight performance loss with huge safety benefits)
- Unify move-only/copyable types
- Improve safety by including more `static_assert` and sanity checks

Refactor type erasure unit tests:
- Difficult to accurately predict the number of constructions and moves, so only enforce an upper bound on copies (at most 1 in the general case)
- Update to new interface

Misc. other files:
- Update to use new ErasedType interface