### PR TITLE
Bump C++ and dependency versions

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.20)
 include(FetchContent)
 
 # Fetch GLFW
@@ -23,5 +23,5 @@ target_include_directories(flappy PRIVATE "../src/")
 target_link_libraries(flappy PRIVATE glfw ${OPENGL_LIBRARIES})
 
 # Compiler features
-target_compile_features(flappy PRIVATE cxx_std_17)
+target_compile_features(flappy PRIVATE cxx_std_23)
 set_target_properties(flappy PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
     glfw
     GIT_REPOSITORY https://github.com/glfw/glfw.git
-    GIT_TAG        3.3.8
+    GIT_TAG        3.4
 )
 set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)

--- a/src/oki/util/oki_handle_gen.h
+++ b/src/oki/util/oki_handle_gen.h
@@ -3,6 +3,7 @@
 
 #include "oki/oki_handle.h"
 
+#include <algorithm>
 #include <forward_list>
 #include <functional>
 #include <unordered_set>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.0.1
+    GIT_TAG        v3.11.0
 )
 FetchContent_MakeAvailable(Catch2)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.20)
 include(FetchContent)
 
 # Fetch and set up Catch2 dependency
@@ -24,7 +24,7 @@ target_include_directories(oki_unit PRIVATE "../src")
 target_link_libraries(oki_unit PRIVATE Catch2::Catch2WithMain)
 
 # Describe compiler features
-target_compile_features(oki_unit PRIVATE cxx_std_17)
+target_compile_features(oki_unit PRIVATE cxx_std_23)
 set_target_properties(oki_unit PROPERTIES CXX_EXTENSIONS OFF)
 
 # Finally, register the unit tests


### PR DESCRIPTION
- Use C++23 instead of C++17
- Use newest releases of GLFW and Catch2
- Fix bug found during compilation